### PR TITLE
Store intermediate data in S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ build-tools:
 	sudo apt install --yes unzip pip awscli
 
 ai2-setup: build-tools install
-	aws configure
 	pip install cc_net[getpy]
 	make dl_lm lang=en
 	make dl_lm lang=ru

--- a/cc_net/ai2_format.py
+++ b/cc_net/ai2_format.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from cc_net import jsonql
+
+class Ai2Formatter(jsonql.Transformer):
+    def __init__(self):
+        super().__init__()
+
+    def do(self, doc: dict) -> Optional[dict]:
+        d = {}
+        d["source"] = "common-crawl"
+        d["id"] = doc["url"]
+        d["text"] = doc["raw_content"]
+        d["added"] = datetime.now(timezone.utc).isoformat()
+        d["created"] = doc["date_download"]
+        m = {}
+        m.update(doc)
+        del m["raw_content"]
+        d["metadata"] = m
+        return d

--- a/cc_net/s3util.py
+++ b/cc_net/s3util.py
@@ -1,0 +1,57 @@
+import re
+import io
+from typing import Tuple
+from pathlib import Path
+
+import boto3
+import botocore
+
+s3_client = boto3.client("s3")
+
+class RetryableDownloadFailure(Exception):
+    def __init__(self, err: Exception):
+        self.err = err
+
+def try_get_content(url: str) -> bytes:
+    bucket,key = _parse_url(url)
+    try:
+        buffer = io.BytesIO()
+        s3_client.download_fileobj(Bucket=bucket,
+                                   Key=key,
+                                   Fileobj=buffer,
+                                   Config=boto3.s3.transfer.TransferConfig(use_threads=False))
+    except botocore.exceptions.ClientError as e:
+        message = e.args[0] if isinstance(e.args[0], str) else ""
+        if not "SlowDown" in message:
+            raise e
+        raise RetryableDownloadFailure(e)
+    return buffer.getvalue()
+
+def exists(url: str) -> bool:
+    bucket,key = _parse_url(url)
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+        return True
+    except botocore.exceptions.ClientError as ex:
+        if ex.response['Error']['Code'] == 'NoSuchKey':
+            return False
+
+def upload(path: Path, url: str):
+    bucket,key = _parse_url(url)
+    with open(path, "rb") as data:
+        s3_client.upload_fileobj(data, bucket, key)
+
+def download(url: str, path: Path):
+    bucket,key = _parse_url(url)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as file:
+        s3_client.download_fileobj(bucket, key, file)
+
+
+def _parse_url(url: str) -> Tuple[str,str]:
+    path_pattern = re.search("s3://([^/]*)/(.*)", url)
+    bucket = path_pattern.group(1)
+    prefix = path_pattern.group(2)
+    return bucket, prefix
+
+

--- a/config/ai2/00-dedup.json
+++ b/config/ai2/00-dedup.json
@@ -1,7 +1,0 @@
-{
-  "config_name": "00-dedup",
-  "mined_dir": "mined_split",
-  "pipeline": ["dedup"],
-  "hash_in_mem": 4,
-  "task_parallelism": 48
-}

--- a/config/ai2/dedup-20gb.json
+++ b/config/ai2/dedup-20gb.json
@@ -1,0 +1,9 @@
+{
+  "config_name": "dedup-20gb",
+  "s3_input_path": "s3://ai2-llm/pretraining-data/sources/common-crawl/raw",
+  "pipeline": ["dedup", "lid", "keep_lang", "sp", "lm", "pp_bucket", "drop", "ai2_format","split_by_lang"],
+  "regroup": false,
+  "hash_max_ram_gb": 20,
+  "mine_num_processes": 1,
+  "task_parallelism": 35
+}

--- a/config/ai2/hashes.json
+++ b/config/ai2/hashes.json
@@ -1,0 +1,7 @@
+{
+  "config_name": "hashes",
+  "pipeline": ["hashes"],
+  "s3_output_path": "s3://ai2-llm/pretraining-data/sources/common-crawl/raw",
+  "mine_num_processes": 1,
+  "task_parallelism": 128
+}

--- a/config/ai2/regroup.json
+++ b/config/ai2/regroup.json
@@ -1,0 +1,8 @@
+{
+  "config_name": "regroup",
+  "s3_output_path": "s3://ai2-llm/pretraining-data/sources/common-crawl/v0/documents",
+  "pipeline": ["dedup", "lid", "keep_lang", "sp", "lm", "pp_bucket", "drop", "ai2_format", "split_by_lang"],
+  "regroup": true,
+  "mine_num_processes": 1,
+  "regroup_parallelism": 192
+}


### PR DESCRIPTION
Add `s3_output_dir` setting to config. If non-empty, outputs files in `data` will be mirrored in S3.

Add `s3_input_dir` to config. If non-empty, pull upstream data from S3 into `data`